### PR TITLE
Enable changing borderType using custom props

### DIFF
--- a/src/FenEditor.js
+++ b/src/FenEditor.js
@@ -98,6 +98,7 @@ export class FenEditor {
             assetsUrl: this.props.assetsUrl,
             style: {
                 aspectRatio: 0.98,
+                borderType: this.props.borderType,
                 pieces: {file: this.props.piecesFile},
                 cssClass: this.props.boardTheme
             },


### PR DESCRIPTION
This small change enables you to set the borderType of your new FednEditor using props.